### PR TITLE
Server object name field

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,27 @@ Notes:
 - `@ApiSecurityDeviceFlow()` is a convenience wrapper around `@ApiSecurity(name, scopes)` for requirements.
 - The device flow scheme definition still comes from `addOAuth2({ flows: { deviceAuthorization: ... } })`.
 
+### 5) Named servers: `DocumentBuilder.addServerWithName()`
+
+This fork extends the `ServerObject` typing with an optional `name?: string`, and provides a convenience builder method to populate it.
+
+```ts
+import { DocumentBuilder } from '@nestjs/swagger';
+
+const config = new DocumentBuilder()
+  .setTitle('t')
+  .setVersion('1')
+  .addServerWithName('prod', 'https://api.example.com', 'Production')
+  .addServerWithName('local', 'https://{host}', 'Local', {
+    host: { default: 'localhost' }
+  })
+  .build();
+```
+
+Signature:
+
+- `addServerWithName(name, url, description?, variables?)`
+
 ## Upstream relationship / migration notes
 
 - The OAS 3.2 support in PR #1 is implemented as an additive extension to minimize breaking changes.

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -72,6 +72,16 @@ export class DocumentBuilder {
     return this;
   }
 
+  public addServerWithName(
+    name: string,
+    url: string,
+    description?: string,
+    variables?: Record<string, ServerVariableObject>
+  ): this {
+    this.document.servers.push({ name, url, description, variables });
+    return this;
+  }
+
   public setExternalDoc(description: string, url: string): this {
     this.document.externalDocs = { description, url };
     return this;

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -35,6 +35,7 @@ export interface LicenseObject {
 }
 
 export interface ServerObject {
+  name?: string;
   url: string;
   description?: string;
   variables?: Record<string, ServerVariableObject>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@nestjs/swagger",
-  "version": "11.2.3",
+  "name": "nestjs-openapi-next",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nestjs/swagger",
-      "version": "11.2.3",
+      "name": "nestjs-openapi-next",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "0.16.0",

--- a/test/document-builder.server.spec.ts
+++ b/test/document-builder.server.spec.ts
@@ -1,0 +1,37 @@
+import { DocumentBuilder } from '../lib/document-builder';
+
+describe('DocumentBuilder.addServerWithName()', () => {
+  it('adds a server entry with name/url/description', () => {
+    const config = new DocumentBuilder()
+      .addServerWithName('prod', 'https://api.example.com', 'Production')
+      .build();
+
+    expect(config.servers?.[0]).toEqual(
+      expect.objectContaining({
+        name: 'prod',
+        url: 'https://api.example.com',
+        description: 'Production'
+      })
+    );
+  });
+
+  it('adds server variables when provided', () => {
+    const config = new DocumentBuilder()
+      .addServerWithName('local', 'https://{host}', 'Local', {
+        host: { default: 'localhost' }
+      })
+      .build();
+
+    expect(config.servers?.[0]).toEqual(
+      expect.objectContaining({
+        name: 'local',
+        url: 'https://{host}',
+        description: 'Local',
+        variables: {
+          host: { default: 'localhost' }
+        }
+      })
+    );
+  });
+});
+


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Currently, the `ServerObject` interface does not include a `name` field, and `DocumentBuilder` only provides `addServer()` which does not allow specifying a server name.

## What is the new behavior?
This PR introduces the following:
- Adds an optional `name?: string` field to the `ServerObject` interface.
- Adds a new `addServerWithName()` method to `DocumentBuilder` to allow adding servers with a specified name, URL, description, and variables.
- Updates the `README.md` to document the new `addServerWithName()` method.
- Adds a new test file `test/document-builder.server.spec.ts` to cover the new functionality.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
This change is additive and provides more flexibility for defining servers in the OpenAPI specification.

---
<a href="https://cursor.com/background-agent?bcId=bc-175224a7-46e6-4dad-b9e5-d0e4af7f636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-175224a7-46e6-4dad-b9e5-d0e4af7f636c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces named server support in the OpenAPI spec and builder.
> 
> - Extends `ServerObject` with optional `name?: string`
> - Adds `DocumentBuilder.addServerWithName(name, url, description?, variables?)` and maintains existing `addServer`
> - Documents the new API in `README.md` and adds tests in `test/document-builder.server.spec.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5f22823430e7b3c9edfd667f8237c67fa38f3426. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->